### PR TITLE
Ground Variable Name Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Y   |     32
 
 #### DESCRIPTION
        Takes  a 32-bit input A, and shifts it left by 2.  Works for Two's Com-
-       pliment values.
+       plement values.
 
 #### AUTHOR
        Alexander T Pastoriza

--- a/SL2_32.bdf
+++ b/SL2_32.bdf
@@ -4,9 +4,9 @@ editor if you plan to continue editing the block that represents it in
 the Block Editor! File corruption is VERY likely to occur.
 */
 /*
-Copyright (C) 2018  Intel Corporation. All rights reserved.
+Copyright (C) 2021  Intel Corporation. All rights reserved.
 Your use of Intel Corporation's design tools, logic functions 
-and other software and tools, and its AMPP partner logic 
+and other software and tools, and any partner logic 
 functions, and any output files from any of the foregoing 
 (including device programming or simulation files), and any 
 associated documentation or information are expressly subject 
@@ -16,7 +16,8 @@ the Intel FPGA IP License Agreement, or other applicable license
 agreement, including, without limitation, that your use is for
 the sole purpose of programming logic devices manufactured by
 Intel and sold by Intel or its authorized distributors.  Please
-refer to the applicable agreement for further details.
+refer to the applicable agreement for further details, at
+https://fpgasoftware.intel.com/eula.
 */
 (header "graphic" (version "1.4"))
 (pin
@@ -1450,16 +1451,16 @@ refer to the applicable agreement for further details.
 	(pt 464 3320)
 )
 (connector
-	(text "Ground" (rect 474 3304 508 3321)(font "Intel Clear" ))
-	(pt 464 3320)
-	(pt 560 3320)
-)
-(connector
 	(pt 464 3464)
 	(pt 464 3440)
 )
 (connector
-	(text "Ground" (rect 474 3424 508 3441)(font "Intel Clear" ))
+	(text "Ground1" (rect 474 3304 514 3321)(font "Intel Clear" ))
+	(pt 464 3320)
+	(pt 560 3320)
+)
+(connector
+	(text "Ground0" (rect 474 3424 514 3441)(font "Intel Clear" ))
 	(pt 464 3440)
 	(pt 568 3440)
 )

--- a/SL2_32.qsf
+++ b/SL2_32.qsf
@@ -41,7 +41,7 @@ set_global_assignment -name DEVICE 5CGXFC7C7F23C8
 set_global_assignment -name TOP_LEVEL_ENTITY SL2_32
 set_global_assignment -name ORIGINAL_QUARTUS_VERSION 18.1.0
 set_global_assignment -name PROJECT_CREATION_TIME_DATE "12:38:18  SEPTEMBER 02, 2020"
-set_global_assignment -name LAST_QUARTUS_VERSION "18.1.0 Lite Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "21.1.0 Lite Edition"
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files
 set_global_assignment -name ERROR_CHECK_FREQUENCY_DIVISOR 256
 set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
@@ -49,7 +49,7 @@ set_global_assignment -name MAX_CORE_JUNCTION_TEMP 85
 set_global_assignment -name EDA_DESIGN_ENTRY_SYNTHESIS_TOOL "Precision Synthesis"
 set_global_assignment -name EDA_LMF_FILE mentor.lmf -section_id eda_design_synthesis
 set_global_assignment -name EDA_INPUT_DATA_FORMAT VQM -section_id eda_design_synthesis
-set_global_assignment -name EDA_SIMULATION_TOOL "ModelSim-Altera (Verilog)"
+set_global_assignment -name EDA_SIMULATION_TOOL "Questa Intel FPGA (Verilog)"
 set_global_assignment -name EDA_TIME_SCALE "1 ps" -section_id eda_simulation
 set_global_assignment -name EDA_OUTPUT_DATA_FORMAT "VERILOG HDL" -section_id eda_simulation
 set_global_assignment -name BDF_FILE SL2_32.bdf

--- a/SL2_32.v
+++ b/SL2_32.v
@@ -1,21 +1,21 @@
-// Copyright (C) 1991-2015 Altera Corporation. All rights reserved.
-// Your use of Altera Corporation's design tools, logic functions 
-// and other software and tools, and its AMPP partner logic 
+// Copyright (C) 2021  Intel Corporation. All rights reserved.
+// Your use of Intel Corporation's design tools, logic functions 
+// and other software and tools, and any partner logic 
 // functions, and any output files from any of the foregoing 
 // (including device programming or simulation files), and any 
 // associated documentation or information are expressly subject 
-// to the terms and conditions of the Altera Program License 
-// Subscription Agreement, the Altera Quartus II License Agreement,
-// the Altera MegaCore Function License Agreement, or other 
-// applicable license agreement, including, without limitation, 
-// that your use is for the sole purpose of programming logic 
-// devices manufactured by Altera and sold by Altera or its 
-// authorized distributors.  Please refer to the applicable 
-// agreement for further details.
+// to the terms and conditions of the Intel Program License 
+// Subscription Agreement, the Intel Quartus Prime License Agreement,
+// the Intel FPGA IP License Agreement, or other applicable license
+// agreement, including, without limitation, that your use is for
+// the sole purpose of programming logic devices manufactured by
+// Intel and sold by Intel or its authorized distributors.  Please
+// refer to the applicable agreement for further details, at
+// https://fpgasoftware.intel.com/eula.
 
-// PROGRAM		"Quartus II 64-Bit"
-// VERSION		"Version 15.0.0 Build 145 04/22/2015 SJ Web Edition"
-// CREATED		"Tue Feb  2 06:28:48 2021"
+// PROGRAM		"Quartus Prime"
+// VERSION		"Version 21.1.0 Build 842 10/21/2021 SJ Lite Edition"
+// CREATED		"Thu Mar 31 23:04:49 2022"
 
 module SL2_32(
 	I,
@@ -26,7 +26,8 @@ module SL2_32(
 input wire	[31:0] I;
 output wire	[31:0] O;
 
-wire	Ground;
+wire	Ground0;
+wire	Ground1;
 wire	[31:0] O_ALTERA_SYNTHESIZED;
 
 
@@ -34,12 +35,12 @@ wire	[31:0] O_ALTERA_SYNTHESIZED;
 
 
 SameBit	b2v_bit00(
-	.Ain(Ground),
+	.Ain(Ground0),
 	.Aout(O_ALTERA_SYNTHESIZED[0]));
 
 
 SameBit	b2v_bit01(
-	.Ain(Ground),
+	.Ain(Ground1),
 	.Aout(O_ALTERA_SYNTHESIZED[1]));
 
 
@@ -195,7 +196,7 @@ SameBit	b2v_bit31(
 
 
 assign	O = O_ALTERA_SYNTHESIZED;
-assign	Ground = 0;
-assign	Ground = 0;
+assign	Ground0 = 0;
+assign	Ground1 = 0;
 
 endmodule


### PR DESCRIPTION
## #Issue
![image](https://user-images.githubusercontent.com/72770921/161188447-bc55afcf-e248-4aea-85da-5bc6347de046.png)

##Fix
Caused by same name in two different wires. Renamed wires to fix.